### PR TITLE
feat: add Google Maps view with controller and route

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,0 +1,4 @@
+class MapsController < ApplicationController
+  def show
+  end
+end

--- a/app/helpers/maps_helper.rb
+++ b/app/helpers/maps_helper.rb
@@ -1,0 +1,2 @@
+module MapsHelper
+end

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Google Map</h1>
+<div id="map" style="height: 500px; width: 100%;"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "maps/show"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -10,5 +11,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "maps#show"
 end

--- a/test/controllers/maps_controller_test.rb
+++ b/test/controllers/maps_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class MapsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get maps_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## Description
This MR adds a Google Maps view to the application. It includes:
- A `Maps` controller with a `show` action.
- A root route pointing to the `maps#show` action.
- A map container in the `app/views/maps/show.html.erb` view.

## Changes
- Generated `Maps` controller with `show` action.
- Updated `config/routes.rb` to set `maps#show` as the root route.
- Added a map container to `app/views/maps/show.html.erb`.

## Testing
1. Start the Rails server:
   ```bash
   rails server
2.Visit the root URL (`http://localhost:3000`) and verify:

- The page displays the "Google Map" heading.

- The map container is visible on the page.

