### PR TITLE
[Feat] Add dynamic Google Maps integration using Stimulus

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,2 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
 import "controllers"

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    latitude: { type: Number, default: 37.7749 },
+    longitude: { type: Number, default: -122.4194 },
+    zoom: { type: Number, default: 12 }
+  }
+
+  connect() {
+    const apiKey = document.querySelector("meta[name='google-maps-api-key']").content;
+
+    if (typeof google === 'undefined') {
+      this.loadScript(apiKey).then(() => this.initMap());
+    } else {
+      this.initMap();
+    }
+  }
+
+  loadScript(apiKey) {
+    return new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}`;
+      script.async = true;
+      script.defer = true;
+      script.onload = resolve;
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+  }
+
+  initMap() {
+    console.log("Initializing map...");
+    const map = new google.maps.Map(this.element, {
+      center: { lat: this.latitudeValue, lng: this.longitudeValue },
+      zoom: this.zoomValue
+    });
+
+    // Add a marker
+    new google.maps.Marker({
+      position: { lat: this.latitudeValue, lng: this.longitudeValue },
+      map: map,
+      title: 'Hello World!'
+    });
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,30 +3,11 @@
 <head>
   <title>MyMapApp</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="google-maps-api-key" content="<%= Rails.application.credentials.google_maps_api_key %>">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
-  <script>
-    function initMap() {
-      const map = new google.maps.Map(document.getElementById("map"), {
-        center: { lat: 27.669360, lng: 85.335518 }, 
-        zoom: 12,
-      });
-
-      // Add a marker
-      new google.maps.Marker({
-        position: { lat: 37.7749, lng: -122.4194 },
-        map: map,
-        title: "Hello World!",
-      });
-    }
-  </script>
-  <script
-    src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.credentials.google_maps_api_key %>&callback=initMap"
-    async
-    defer
-  ></script>
 </head>
 <body>
   <%= yield %>

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -1,2 +1,7 @@
 <h1>Google Map</h1>
-<div id="map" style="height: 500px; width: 100%;"></div>
+<div data-controller="map"
+    data-map-latitude-value="27.669360"
+    data-map-longitude-value="85.335518"
+    data-map-zoom-value="12"
+    style="height: 500px; width: 100%;">
+</div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,7 +1,6 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
-pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
## Description
This MR adds dynamic Google Maps integration using Stimulus. It includes:
- Installation of Stimulus for frontend interactivity.
- Creation of a `map_controller` to dynamically load and initialize the map.
- Updated view to use the Stimulus controller for dynamic map rendering.

## Changes
- Installed Stimulus using `rails stimulus:install`.
- Generated a `map_controller` with dynamic map loading logic.
- Updated `app/views/maps/show.html.erb` to use the Stimulus controller.

## Checklist
- [X] Stimulus installed and configured.
- [X] map_controller created with dynamic map loading logic.
- [X] View updated to use the Stimulus controller.